### PR TITLE
Add missing include of cymric.h

### DIFF
--- a/src/cymric-aes128/x86_64/aesni.c
+++ b/src/cymric-aes128/x86_64/aesni.c
@@ -1,3 +1,4 @@
+#include "cymric.h"
 #include "aes.h"
 
 cipher_ctx_t aes_get_cipher_ctx(void) {


### PR DESCRIPTION
Required to get the KEYBYTES and BLOCKBYTES definitions.